### PR TITLE
PHP 8.4 compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,3 +45,35 @@ jobs:
 
       - name: Tests
         run: composer test
+
+  rector:
+    name: Rector
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        php:
+          - 8.4
+      fail-fast: false
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+
+      - name: Cache PHP dependencies
+        uses: actions/cache@v4
+        with:
+          path: vendor
+          key: ${{ runner.os }}-php-${{ matrix.php }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-php-${{ matrix.php }}-composer-
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress --no-suggest
+
+      - name: Tests
+        run: vendor/bin/rector process --dry-run

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,15 +17,16 @@ jobs:
           - 7.2
           - 7.3
           - 7.4
-        composer-args: [ "" ]
-        include:
-          - php: 8.0
-            composer-args: --ignore-platform-reqs
+          - 8.0
+          - 8.1
+          - 8.2
+          - 8.3
+          - 8.4
       fail-fast: false
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
@@ -33,14 +34,14 @@ jobs:
           php-version: ${{ matrix.php }}
 
       - name: Cache PHP dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: vendor
           key: ${{ runner.os }}-php-${{ matrix.php }}-composer-${{ hashFiles('**/composer.json') }}
           restore-keys: ${{ runner.os }}-php-${{ matrix.php }}-composer-
 
       - name: Install dependencies
-        run: composer install --prefer-dist --no-progress --no-suggest ${{ matrix.composer-args }}
+        run: composer install --prefer-dist --no-progress --no-suggest
 
       - name: Tests
         run: composer test

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
         "phpunit/phpunit": "^8.0",
         "squizlabs/php_codesniffer": "^3.0",
         "oscarotero/php-cs-fixer-config": "^1.0",
-        "friendsofphp/php-cs-fixer": "^2.15"
+        "friendsofphp/php-cs-fixer": "^2.15",
+        "rector/rector": "^1|^2"
     },
     "autoload": {
         "psr-4": {
@@ -43,6 +44,7 @@
             "phpunit",
             "phpcs"
         ],
-        "cs-fix": "php-cs-fixer fix"
+        "cs-fix": "php-cs-fixer fix",
+        "rector": "rector process"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "squizlabs/php_codesniffer": "^3.0",
         "oscarotero/php-cs-fixer-config": "^1.0",
         "friendsofphp/php-cs-fixer": "^2.15",
+        "phpstan/phpstan": "^1|^2",
         "rector/rector": "^1|^2"
     },
     "autoload": {
@@ -42,7 +43,8 @@
     "scripts": {
         "test": [
             "phpunit",
-            "phpcs"
+            "phpcs",
+            "phpstan"
         ],
         "cs-fix": "php-cs-fixer fix",
         "rector": "rector process"

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -1,0 +1,5 @@
+parameters:
+    level: 5
+    paths:
+    - src
+    - tests

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Set\ValueObject\SetList;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ])
+    ->withPhpSets()
+    ->withPreparedSets(typeDeclarations: true)
+    ->withDeadCodeLevel(2)
+    ->withCodeQualityLevel(10)
+    ->withCodingStyleLevel(0)
+;

--- a/src/JsFunctionsScanner.php
+++ b/src/JsFunctionsScanner.php
@@ -11,7 +11,7 @@ class JsFunctionsScanner implements FunctionsScannerInterface
     protected $validFunctions;
     protected $parser;
 
-    public function __construct(array $validFunctions = null)
+    public function __construct(?array $validFunctions = null)
     {
         $this->validFunctions = $validFunctions;
         $this->parser('latest');

--- a/src/JsFunctionsScanner.php
+++ b/src/JsFunctionsScanner.php
@@ -26,7 +26,7 @@ class JsFunctionsScanner implements FunctionsScannerInterface
 
     public function scan(string $code, string $filename): array
     {
-        list($version, $options) = $this->parser;
+        [$version, $options] = $this->parser;
 
         $ast = Peast::$version($code, $options)->parse();
 

--- a/src/JsNodeVisitor.php
+++ b/src/JsNodeVisitor.php
@@ -19,7 +19,7 @@ class JsNodeVisitor
         $this->validFunctions = $validFunctions;
     }
 
-    public function __invoke(Node $node)
+    public function __invoke(Node $node): void
     {
         if ($node->getType() === 'CallExpression') {
             $function = $this->createFunction($node);
@@ -109,7 +109,7 @@ class JsNodeVisitor
     {
         $text = $comment->getText();
 
-        $lines = array_map(function ($line) {
+        $lines = array_map(function ($line): string {
             $line = ltrim($line, "#*/ \t");
             $line = rtrim($line, "#*/ \t");
             return trim($line);

--- a/src/JsNodeVisitor.php
+++ b/src/JsNodeVisitor.php
@@ -3,9 +3,14 @@ declare(strict_types = 1);
 
 namespace Gettext\Scanner;
 
+use InvalidArgumentException;
 use Peast\Syntax\Node\CallExpression;
 use Peast\Syntax\Node\Comment;
+use Peast\Syntax\Node\Identifier;
+use Peast\Syntax\Node\Literal;
+use Peast\Syntax\Node\MemberExpression;
 use Peast\Syntax\Node\Node;
+use Peast\Syntax\Node\TemplateLiteral;
 
 class JsNodeVisitor
 {
@@ -21,7 +26,7 @@ class JsNodeVisitor
 
     public function __invoke(Node $node): void
     {
-        if ($node->getType() === 'CallExpression') {
+        if ($node instanceof CallExpression) {
             $function = $this->createFunction($node);
 
             if ($function) {
@@ -55,24 +60,20 @@ class JsNodeVisitor
         static::addComments($function, $node->getCallee());
 
         foreach ($node->getArguments() as $argument) {
-            switch ($argument->getType()) {
-                case 'Literal':
-                    $function->addArgument($argument->getValue());
-                    static::addComments($function, $argument);
-                    break;
-                case 'TemplateLiteral':
-                    if ($argument->getExpressions()) {
-                        $function->addArgument();
-                        break;
-                    }
-
+            if ($argument instanceof Literal) {
+                $function->addArgument($argument->getValue());
+                static::addComments($function, $argument);
+            } elseif ($argument instanceof TemplateLiteral) {
+                if ($argument->getExpressions()) {
+                    $function->addArgument();
+                } else {
                     $quasis = $argument->getQuasis();
                     $quasis = array_shift($quasis);
                     $function->addArgument($quasis->getValue());
                     static::addComments($function, $argument);
-                    break;
-                default:
-                    $function->addArgument();
+                }
+            } else {
+                $function->addArgument();
             }
         }
 
@@ -83,19 +84,15 @@ class JsNodeVisitor
     {
         $callee = $node->getCallee();
 
-        switch ($callee->getType()) {
-            case 'Identifier':
-                return $callee->getName();
-            case 'MemberExpression':
-                $property = $callee->getProperty();
-
-                if ($property->getType() === 'Identifier') {
-                    return $property->getName();
-                }
-                return null;
-            default:
-                return null;
+        if ($callee instanceof Identifier) {
+            return $callee->getName();
+        } elseif ($callee instanceof MemberExpression) {
+            $property = $callee->getProperty();
+            if ($property instanceof Identifier) {
+                return $property->getName();
+            }
         }
+        return null;
     }
 
     protected static function addComments(ParsedFunction $function, Node $node): void

--- a/src/JsNodeVisitor.php
+++ b/src/JsNodeVisitor.php
@@ -18,7 +18,7 @@ class JsNodeVisitor
     protected $filename;
     protected $functions = [];
 
-    public function __construct(string $filename, array $validFunctions = null)
+    public function __construct(string $filename, ?array $validFunctions = null)
     {
         $this->filename = $filename;
         $this->validFunctions = $validFunctions;

--- a/tests/JsFunctionsScannerTest.php
+++ b/tests/JsFunctionsScannerTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 
 class JsFunctionsScannerTest extends TestCase
 {
-    public function testJsFunctionsExtractor()
+    public function testJsFunctionsExtractor(): void
     {
         $scanner = new JsFunctionsScanner();
         $file = __DIR__.'/assets/functions.js';


### PR DESCRIPTION
Hi,

PHP 8.4 deprecates implicit null types.
EmTeedee@b377d82ab55cd6109704fd9a9af3e510c236a0d7 fixes this issue.

To make sure the pull request is properly tested, I mirrored the github workflow and tests from php-gettext/Gettext.
So this pull request adds php 8.0-8.4 to the workflow as well as Rector and phpstan.

Hope this helps.